### PR TITLE
Solution to disable dummy cache on all environments but still have the option available for local development.

### DIFF
--- a/parkpasses/settings.py
+++ b/parkpasses/settings.py
@@ -100,8 +100,8 @@ TEMPLATES[0]["DIRS"].append(os.path.join(BASE_DIR, "parkpasses", "templates"))
 TEMPLATES[0]["DIRS"].append(
     os.path.join(BASE_DIR, "parkpasses", "components", "emails", "templates")
 )
-
-if DEBUG:
+USE_DUMMY_CACHE = env("USE_DUMMY_CACHE", False)
+if USE_DUMMY_CACHE:
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",


### PR DESCRIPTION
Added env variable that only enables dummy cache if present and set to True so by default will only use dummy cache on my local machine but will use disk cache in all other environments.